### PR TITLE
chore: Remove origin from document resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@
   - spreadsheet ⇒ sheet
 - creator
   - 랜덤 string 값
-- origin
-  - 랜덤 string 값
 
 #### URL 리소스
 

--- a/api.yaml
+++ b/api.yaml
@@ -79,7 +79,6 @@ paths:
                       metadata:
                         doctype: doc
                         creator: 작성자1
-                        origin: paramId123
                       id: '1234'
                     - id: '12345'
                       name: URL리소스
@@ -164,7 +163,6 @@ components:
           metadata:
             doctype: doc
             creator: 작성자
-            origin: 123_origin
           id: '123444'
           links:
             - id: '1234'
@@ -183,13 +181,10 @@ components:
           required:
             - doctype
             - creator
-            - origin
           properties:
             doctype:
               type: string
             creator:
-              type: string
-            origin:
               type: string
         id:
           type: string


### PR DESCRIPTION
`origin` 이 `creator` 와 동일한 스펙이어서 제거해도 될 것 같아 제거했습니다.