### PR TITLE
Add path to metadata of document resource

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -77,6 +77,7 @@ paths:
                     - type: document
                       name: 도큐먼트
                       metadata:
+                        path: 'https://docs.google.com/document/d/document_id_1234'
                         doctype: doc
                         creator: 작성자1
                       id: '1234'
@@ -161,6 +162,7 @@ components:
           type: document
           name: "도큐먼트\U0001F604"
           metadata:
+            path: 'https://docs.google.com/document/d/document_id_1234'
             doctype: doc
             creator: 작성자
           id: '123444'
@@ -181,9 +183,12 @@ components:
         metadata:
           type: object
           required:
+            - path
             - doctype
             - creator
           properties:
+            path:
+              type: string
             doctype:
               type: string
             creator:


### PR DESCRIPTION
기존에 의미가 불명확했던 `origin` 을 제거했던 부분을 보충하기 위해 document resource 에도 url resource 와 마찬가지로 `metadata` 에 `path` 를 추가합니다.